### PR TITLE
fix: hide password on error

### DIFF
--- a/postgresql/config.go
+++ b/postgresql/config.go
@@ -274,7 +274,8 @@ func (c *Client) Connect() (*DBConnection, error) {
 			db, err = postgres.Open(context.Background(), dsn)
 		}
 		if err != nil {
-			return nil, fmt.Errorf("Error connecting to PostgreSQL server %s (scheme: %s): %w", c.config.Host, c.config.Scheme, err)
+			errString := strings.Replace(err.Error(), c.config.Password, "XXXX", 2)
+			return nil, fmt.Errorf("Error connecting to PostgreSQL server %s (scheme: %s): %s", c.config.Host, c.config.Scheme, errString)
 		}
 
 		// We don't want to retain connection


### PR DESCRIPTION
The password is part of the connection string and will be outputed to logs in case of an error.

Remove it in case it's present.